### PR TITLE
DBZ-7175 Correctly calculate Max LSN

### DIFF
--- a/src/main/java/io/debezium/connector/informix/InformixConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/informix/InformixConnectorConfig.java
@@ -138,7 +138,6 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
 
         /**
          * This mode will block all reads and writes for the entire duration of the snapshot.
-         *
          * The connector will execute {@code SELECT * FROM .. WITH (TABLOCKX)}
          */
         EXCLUSIVE("exclusive"),
@@ -356,8 +355,8 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
         return new HistoryRecordComparator() {
             @Override
             protected boolean isPositionAtOrBefore(Document recorded, Document desired) {
-                return Lsn.valueOf(recorded.getString(SourceInfo.CHANGE_LSN_KEY))
-                        .compareTo(Lsn.valueOf(desired.getString(SourceInfo.CHANGE_LSN_KEY))) < 1;
+                return Lsn.of(recorded.getString(SourceInfo.CHANGE_LSN_KEY))
+                        .compareTo(Lsn.of(desired.getString(SourceInfo.CHANGE_LSN_KEY))) < 1;
             }
         };
     }

--- a/src/main/java/io/debezium/connector/informix/InformixOffsetContext.java
+++ b/src/main/java/io/debezium/connector/informix/InformixOffsetContext.java
@@ -141,9 +141,9 @@ public class InformixOffsetContext extends CommonOffsetContext<SourceInfo> {
 
         @Override
         public InformixOffsetContext load(Map<String, ?> offset) {
-            final Lsn commitLsn = Lsn.valueOf((String) offset.get(SourceInfo.COMMIT_LSN_KEY));
-            final Lsn changeLsn = Lsn.valueOf((String) offset.get(SourceInfo.CHANGE_LSN_KEY));
-            final Lsn beginLsn = Lsn.valueOf((String) offset.get(SourceInfo.BEGIN_LSN_KEY));
+            final Lsn commitLsn = Lsn.of((String) offset.get(SourceInfo.COMMIT_LSN_KEY));
+            final Lsn changeLsn = Lsn.of((String) offset.get(SourceInfo.CHANGE_LSN_KEY));
+            final Lsn beginLsn = Lsn.of((String) offset.get(SourceInfo.BEGIN_LSN_KEY));
 
             boolean snapshot = Boolean.TRUE.equals(offset.get(SourceInfo.SNAPSHOT_KEY));
             boolean snapshotCompleted = Boolean.TRUE.equals(offset.get(SNAPSHOT_COMPLETED_KEY));

--- a/src/main/java/io/debezium/connector/informix/InformixSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/informix/InformixSnapshotChangeEventSource.java
@@ -82,7 +82,7 @@ public class InformixSnapshotChangeEventSource extends RelationalSnapshotChangeE
     }
 
     @Override
-    protected SnapshotContext<InformixPartition, InformixOffsetContext> prepare(InformixPartition partition) throws Exception {
+    protected SnapshotContext<InformixPartition, InformixOffsetContext> prepare(InformixPartition partition) {
         return new InformixSnapshotContext(partition, jdbcConnection.getRealDatabaseName());
     }
 
@@ -143,7 +143,8 @@ public class InformixSnapshotChangeEventSource extends RelationalSnapshotChangeE
     }
 
     @Override
-    protected void determineSnapshotOffset(RelationalSnapshotContext<InformixPartition, InformixOffsetContext> ctx, InformixOffsetContext previousOffset) {
+    protected void determineSnapshotOffset(RelationalSnapshotContext<InformixPartition, InformixOffsetContext> ctx, InformixOffsetContext previousOffset)
+            throws SQLException {
         InformixOffsetContext offset = ctx.offset;
         if (offset == null) {
             if (previousOffset != null) {
@@ -246,7 +247,7 @@ public class InformixSnapshotChangeEventSource extends RelationalSnapshotChangeE
         private int isolationLevelBeforeStart;
         private Savepoint preSchemaSnapshotSavepoint;
 
-        InformixSnapshotContext(InformixPartition partition, String catalogName) throws SQLException {
+        InformixSnapshotContext(InformixPartition partition, String catalogName) {
             super(partition, catalogName);
         }
     }

--- a/src/main/java/io/debezium/connector/informix/TxLogPosition.java
+++ b/src/main/java/io/debezium/connector/informix/TxLogPosition.java
@@ -34,29 +34,16 @@ public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
         this.beginLsn = beginLsn;
     }
 
-    public static TxLogPosition valueOf(Lsn commitLsn) {
-        if (commitLsn == null || commitLsn.equals(Lsn.NULL)) {
-            return NULL;
-        }
-        return valueOf(commitLsn, Lsn.valueOf(0x00L));
+    public static TxLogPosition current() {
+        return TxLogPosition.valueOf(Lsn.of(0x00L));
     }
 
-    public static TxLogPosition valueOf(Lsn commitLsn, Lsn changeLsn) {
-        if ((commitLsn == null || commitLsn.equals(Lsn.NULL) && (changeLsn == null || changeLsn.equals(Lsn.NULL)))) {
-            return NULL;
-        }
-        else {
-            return valueOf(commitLsn, changeLsn, Lsn.valueOf(0x00L));
-        }
+    public static TxLogPosition valueOf(Lsn sequence) {
+        return sequence == null || !sequence.isAvailable() ? NULL : valueOf(sequence, Lsn.of(0x00L), sequence);
     }
 
     public static TxLogPosition valueOf(Lsn commitLsn, Lsn changeLsn, Lsn beginLsn) {
-        if ((commitLsn == null || commitLsn.equals(Lsn.NULL) && (changeLsn == null || changeLsn.equals(Lsn.NULL)))) {
-            return NULL;
-        }
-        else {
-            return valueOf(commitLsn, changeLsn, 0x00, beginLsn);
-        }
+        return valueOf(commitLsn, changeLsn, -1, beginLsn);
     }
 
     public static TxLogPosition valueOf(Lsn commitLsn, Lsn changeLsn, Integer txId, Lsn beginLsn) {
@@ -70,10 +57,6 @@ public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
                 changeLsn.compareTo(position.changeLsn) > 0 ? changeLsn : position.changeLsn,
                 txId >= 0 ? txId : position.txId,
                 beginLsn.compareTo(position.beginLsn) > 0 ? beginLsn : position.beginLsn);
-    }
-
-    public static TxLogPosition clone(TxLogPosition position) {
-        return valueOf(position.commitLsn, position.changeLsn, position.txId, position.beginLsn);
     }
 
     public Lsn getCommitLsn() {

--- a/src/test/java/io/debezium/connector/informix/LsnTest.java
+++ b/src/test/java/io/debezium/connector/informix/LsnTest.java
@@ -13,8 +13,8 @@ public class LsnTest {
 
     @Test
     public void testLsnMinusOne() {
-        Lsn recorded = Lsn.valueOf("1000");
-        Lsn desired = Lsn.valueOf("1046");
+        Lsn recorded = Lsn.of("1000");
+        Lsn desired = Lsn.of("1046");
         int ret = recorded.compareTo(desired);
         System.out.println(ret);
         // assertThat(ret).isEqualTo(-1);
@@ -29,19 +29,19 @@ public class LsnTest {
     @Test
     public void testLsnNULL() {
         Lsn recorded = Lsn.NULL;
-        Lsn desired = Lsn.valueOf("146031505564");
+        Lsn desired = Lsn.of("146031505564");
         assertThat(recorded).isLessThan(desired);
 
-        Lsn recorded1 = Lsn.valueOf("NULL");
-        Lsn desired1 = Lsn.valueOf("146031505564");
+        Lsn recorded1 = Lsn.of("NULL");
+        Lsn desired1 = Lsn.of("146031505564");
         assertThat(recorded1).isLessThan(desired1);
     }
 
     @Test
     public void testValueOf() {
         String lsnStr = "146039087264";
-        Lsn lsn1 = Lsn.valueOf(lsnStr);
-        Lsn lsn2 = Lsn.valueOf(146039087264L);
+        Lsn lsn1 = Lsn.of(lsnStr);
+        Lsn lsn2 = Lsn.of(146039087264L);
         Lsn lsn3 = new Lsn(146039087264L);
 
         assertThat(lsn1).isEqualTo(lsn2);
@@ -72,14 +72,14 @@ public class LsnTest {
 
     @Test
     public void testLsnValueOf() {
-        Lsn lsnNegativeOne = Lsn.valueOf(-1L);
-        Lsn lsnNegativeOneStr = Lsn.valueOf("-1");
-        Lsn lsnDigit1 = Lsn.valueOf("1");
-        Lsn lsnDigit2 = Lsn.valueOf("12");
-        Lsn lsnDigit3 = Lsn.valueOf("123");
-        Lsn lsnDigit4 = Lsn.valueOf("1234");
-        Lsn lsnDigit5 = Lsn.valueOf("12345");
-        Lsn lsnDigit6 = Lsn.valueOf("123456");
+        Lsn lsnNegativeOne = Lsn.of(-1L);
+        Lsn lsnNegativeOneStr = Lsn.of("-1");
+        Lsn lsnDigit1 = Lsn.of("1");
+        Lsn lsnDigit2 = Lsn.of("12");
+        Lsn lsnDigit3 = Lsn.of("123");
+        Lsn lsnDigit4 = Lsn.of("1234");
+        Lsn lsnDigit5 = Lsn.of("12345");
+        Lsn lsnDigit6 = Lsn.of("123456");
 
         assertThat(lsnNegativeOne).isEqualTo(lsnNegativeOneStr).isEqualByComparingTo(lsnNegativeOneStr);
 
@@ -98,7 +98,7 @@ public class LsnTest {
 
     @Test
     public void testLsnLongString() {
-        Lsn lsn = Lsn.valueOf("30073823388");
+        Lsn lsn = Lsn.of("30073823388");
 
         assertThat(lsn.toLongString()).isEqualTo("LSN(7,8a209c)");
     }

--- a/src/test/java/io/debezium/connector/informix/SourceInfoTest.java
+++ b/src/test/java/io/debezium/connector/informix/SourceInfoTest.java
@@ -32,8 +32,8 @@ public class SourceInfoTest {
                         .with(InformixConnectorConfig.DATABASE_NAME, "c")
                         .build());
         source = new SourceInfo(connectorConfig);
-        source.setChangeLsn(Lsn.valueOf(0x01L));
-        source.setCommitLsn(Lsn.valueOf(0x02L));
+        source.setChangeLsn(Lsn.of(0x01L));
+        source.setCommitLsn(Lsn.of(0x02L));
         source.setSnapshot(SnapshotRecord.TRUE);
         source.setTimestamp(Instant.ofEpochMilli(3000));
         source.setTableId(new TableId("c", "s", "t"));


### PR DESCRIPTION
Correctly retrieve and calculate the highest available Log Sequence Number from the database and pass it on to the SnapshotChangeEventSource to correctly determine the SnapshotOffset.