### PR TITLE
DBZ-5071 Correctly handle NULL values in incremental snapshots

### DIFF
--- a/src/main/java/io/debezium/connector/informix/InformixConnection.java
+++ b/src/main/java/io/debezium/connector/informix/InformixConnection.java
@@ -118,6 +118,13 @@ public class InformixConnection extends JdbcConnection {
     }
 
     @Override
+    public Optional<Boolean> nullsSortLast() {
+        // "NULL values by default are ordered as less than values that are not NULL"
+        // https://www.ibm.com/docs/en/informix-servers/14.10?topic=clause-ascending-descending-orders#ids_sqs_1055
+        return Optional.of(false);
+    }
+
+    @Override
     public String quotedTableIdString(TableId tableId) {
         // TODO: Unless DELIMIDENT is set, table names cannot be quoted
         StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
This makes changes in the Informix connector for the corresponding commit in the main Debezium project.  The main thing we have to do is override the nullsSortLast function in InformixConnection to define how NULLs sort in Informix.  We also have to update the test suite, since the base test suite now includes additional tests for working with keys that are nullable.

Related pull request: https://github.com/debezium/debezium/pull/5158