### PR TITLE
DBZ-9020 - Revert "Align to core changes (#79)"

### DIFF
--- a/src/main/java/io/debezium/connector/informix/InformixConnectorTask.java
+++ b/src/main/java/io/debezium/connector/informix/InformixConnectorTask.java
@@ -10,7 +10,6 @@ import static io.debezium.heartbeat.HeartbeatErrorHandler.DEFAULT_NOOP_ERRORHAND
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.errors.ConnectException;
@@ -185,21 +184,11 @@ public class InformixConnectorTask extends BaseSourceTask<InformixPartition, Inf
     }
 
     @Override
-    protected String connectorName() {
-        return Module.name();
-    }
-
-    @Override
     protected List<SourceRecord> doPoll() throws InterruptedException {
 
         return queue.poll().stream()
                 .map(DataChangeEvent::getRecord)
                 .collect(Collectors.toList());
-    }
-
-    @Override
-    protected Optional<ErrorHandler> getErrorHandler() {
-        return Optional.of(errorHandler);
     }
 
     @Override


### PR DESCRIPTION
This reverts commit 52103c4f08a6a7ba64878433254828574ca90a07.

(Re-applied by #85)