### PR TITLE
DBZ-8773 - Support for Informix Delimited Identifiers

### DIFF
--- a/.github/workflows/cross-maven.yml
+++ b/.github/workflows/cross-maven.yml
@@ -63,17 +63,25 @@ jobs:
           distribution: temurin
           java-version: 21
 
+      # This job builds and creates/restores the cache based on the hash of the POM files from the core
+      # repository; therefore, we need to output this so that the matrix job can reuse this cache.
+      - name: Generate Cache Key
+        id: cache-key-generator
+        run: echo "cache-key=${{ runner.os }}-m2-${{ hashFiles('core/**/pom.xml') }}${{ steps.branch.outputs.BRANCH_FOUND == 'true' && github.head_ref || '' }}" >> "$GITHUB_OUTPUT"
+
       - name: Cache Maven Repository
+        id: cache-check
         uses: actions/cache@v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-m2-${{ hashFiles('core/**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2-${{ hashFiles('core/**/pom.xml') }}
+          key: ${{ steps.cache-key-generator.outputs.cache-key }}
+          restore-keys: ${{ steps.cache-key-generator.outputs.cache-key }}
 
       - name: Build Debezium (Core)
+        if: steps.cache-check.outputs.cache-hit != 'true'
         run: >
           ./core/mvnw clean install -B -ntp -f core/pom.xml
-          -pl debezium-assembly-descriptors,debezium-bom,debezium-core,debezium-embedded,:debezium-ide-configs,:debezium-checkstyle,:debezium-revapi
+          -pl debezium-assembly-descriptors,debezium-bom,debezium-core,debezium-embedded,:debezium-storage-file,:debezium-storage-kafka,:debezium-ide-configs,:debezium-checkstyle,:debezium-revapi
           -am
           -DskipTests=true
           -DskipITs=true
@@ -83,12 +91,6 @@ jobs:
           -Dhttp.keepAlive=false
           -Dmaven.wagon.http.pool=false
           -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-
-      # This job builds and creates/restores the cache based on the hash of the POM files from the core
-      # repository; therefore, we need to output this so that the matrix job can reuse this cache.
-      - name: Generate Cache Key
-        id: cache-key-generator
-        run: echo "cache-key=${{ runner.os }}-m2-${{ hashFiles('core/**/pom.xml') }}" >> "$GITHUB_OUTPUT"
 
   build_informix:
     strategy:

--- a/.github/workflows/cross-maven.yml
+++ b/.github/workflows/cross-maven.yml
@@ -130,6 +130,7 @@ jobs:
           -Dhttp.keepAlive=false
           -Dmaven.wagon.http.pool=false
           -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-          -Ddebezium.test.records.waittime=7
-          -Ddebezium.test.records.waittime.after.nulls=15
+          -Ddebezium.test.engine.waittime=13
+          -Ddebezium.test.records.waittime=13
+          -Ddebezium.test.records.waittime.after.nulls=13
           -DfailFlakyTests=false

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,17 +34,25 @@ jobs:
           distribution: temurin
           java-version: 21
 
+      # This job builds and creates/restores the cache based on the hash of the POM files from the core
+      # repository; therefore, we need to output this so that the matrix job can reuse this cache.
+      - name: Generate Cache Key
+        id: cache-key-generator
+        run: echo "cache-key=${{ runner.os }}-m2-${{ hashFiles('core/**/pom.xml') }}" >> "$GITHUB_OUTPUT"
+
       - name: Cache Maven Repository
+        id: cache-check
         uses: actions/cache@v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-m2-${{ hashFiles('core/**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2-${{ hashFiles('core/**/pom.xml') }}
+          key: ${{ steps.cache-key-generator.outputs.cache-key }}
+          restore-keys: ${{ steps.cache-key-generator.outputs.cache-key }}
 
       - name: Build Debezium (Core)
+        if: steps.cache-check.outputs.cache-hit != 'true'
         run: >
           ./core/mvnw clean install -B -ntp -f core/pom.xml
-          -pl debezium-assembly-descriptors,debezium-bom,debezium-core,debezium-embedded,:debezium-ide-configs,:debezium-checkstyle,:debezium-revapi
+          -pl debezium-assembly-descriptors,debezium-bom,debezium-core,debezium-embedded,:debezium-storage-file,:debezium-storage-kafka,:debezium-ide-configs,:debezium-checkstyle,:debezium-revapi
           -am
           -DskipTests=true
           -DskipITs=true
@@ -54,12 +62,6 @@ jobs:
           -Dhttp.keepAlive=false
           -Dmaven.wagon.http.pool=false
           -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-
-      # This job builds and creates/restores the cache based on the hash of the POM files from the core
-      # repository; therefore, we need to output this so that the matrix job can reuse this cache.
-      - name: Generate Cache Key
-        id: cache-key-generator
-        run: echo "cache-key=${{ runner.os }}-m2-${{ hashFiles('core/**/pom.xml') }}" >> "$GITHUB_OUTPUT"
 
   build_informix:
     strategy:
@@ -101,6 +103,7 @@ jobs:
           -Dhttp.keepAlive=false
           -Dmaven.wagon.http.pool=false
           -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-          -Ddebezium.test.records.waittime=7
-          -Ddebezium.test.records.waittime.after.nulls=15
+          -Ddebezium.test.engine.waittime=13
+          -Ddebezium.test.records.waittime=13
+          -Ddebezium.test.records.waittime.after.nulls=13
           -DfailFlakyTests=false

--- a/src/main/java/io/debezium/connector/informix/InformixCdcTransactionEngine.java
+++ b/src/main/java/io/debezium/connector/informix/InformixCdcTransactionEngine.java
@@ -172,8 +172,8 @@ public class InformixCdcTransactionEngine implements IfxTransactionEngine {
          */
         tableIdByLabelId = engine.getBuilder().getWatchedTables().stream()
                 .collect(Collectors.toUnmodifiableMap(
-                        o -> String.valueOf(o.getLabel()),
-                        t -> new TableId(t.getDatabaseName(), t.getNamespace(), t.getTableName())));
+                        t -> String.valueOf(t.getLabel()),
+                        t -> TableId.parse("%s.%s.%s".formatted(t.getDatabaseName(), t.getNamespace(), t.getTableName()))));
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/informix/InformixChangeTable.java
+++ b/src/main/java/io/debezium/connector/informix/InformixChangeTable.java
@@ -5,9 +5,10 @@
  */
 package io.debezium.connector.informix;
 
+import io.debezium.relational.ChangeTable;
 import io.debezium.relational.TableId;
 
-public class InformixChangeTable {
+public class InformixChangeTable extends ChangeTable {
 
     private static final String CDC_SCHEMA = "syscdcsv1";
 
@@ -24,19 +25,13 @@ public class InformixChangeTable {
     /**
      * The table in the CDC schema that captures changes, suitably quoted for Informix
      */
-    private final String captureInstance;
-
-    private int changeTableObjectId;
-    private TableId sourceTableId;
-    private TableId changeTableId;
+    private final String ifxCaptureInstance;
 
     public InformixChangeTable(TableId sourceTableId, String captureInstance, int changeTableObjectId, Lsn startLsn, Lsn stopLsn) {
-        this.sourceTableId = sourceTableId;
-        this.changeTableObjectId = changeTableObjectId;
+        super(captureInstance, sourceTableId, resolveChangeTableId(sourceTableId, captureInstance, CDC_SCHEMA), changeTableObjectId);
         this.startLsn = startLsn;
         this.stopLsn = stopLsn;
-        this.captureInstance = captureInstance;
-        this.changeTableId = (sourceTableId != null) ? new TableId(InformixChangeTable.CDC_SCHEMA, sourceTableId.schema(), captureInstance) : null;
+        this.ifxCaptureInstance = InformixIdentifierQuoter.quoteIfNecessary(captureInstance);
     }
 
     public InformixChangeTable(String captureInstance, int changeTableObjectId, Lsn startLsn, Lsn stopLsn) {
@@ -44,7 +39,7 @@ public class InformixChangeTable {
     }
 
     public String getCaptureInstance() {
-        return captureInstance;
+        return ifxCaptureInstance;
     }
 
     public Lsn getStartLsn() {
@@ -59,16 +54,8 @@ public class InformixChangeTable {
         this.stopLsn = stopLsn;
     }
 
-    public TableId getSourceTableId() {
-        return sourceTableId;
-    }
-
-    public TableId getChangeTableId() {
-        return changeTableId;
-    }
-
-    public int getChangeTableObjectId() {
-        return changeTableObjectId;
+    private static TableId resolveChangeTableId(TableId sourceTableId, String captureInstance, String cdcSchema) {
+        return sourceTableId != null ? new TableId(CDC_SCHEMA, sourceTableId.schema(), InformixIdentifierQuoter.quoteIfNecessary(captureInstance)) : null;
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/informix/InformixConnection.java
+++ b/src/main/java/io/debezium/connector/informix/InformixConnection.java
@@ -46,7 +46,7 @@ public class InformixConnection extends JdbcConnection {
 
     private static final String GET_CURRENT_TIMESTAMP = "select sysdate as sysdate from sysmaster:sysdual";
 
-    private static final String QUOTED_CHARACTER = ""; // TODO: Unless DELIMIDENT is set, column names cannot be quoted
+    private static final String QUOTED_CHARACTER = ""; // Unless DELIMIDENT is set, database identifiers cannot be quoted
 
     private static final String URL_PATTERN = "jdbc:informix-sqli://${"
             + JdbcConfiguration.HOSTNAME + "}:${"
@@ -162,26 +162,24 @@ public class InformixConnection extends JdbcConnection {
 
     @Override
     public String quotedTableIdString(TableId tableId) {
-        // TODO: Unless DELIMIDENT is set, table names cannot be quoted
-        StringBuilder builder = new StringBuilder();
+        // Unless DELIMIDENT is set, database identifiers cannot be quoted
+        StringBuilder quoted = new StringBuilder();
 
-        String catalogName = tableId.catalog();
-        if (!Strings.isNullOrBlank(catalogName)) {
-            builder.append(catalogName).append(':');
+        if (!Strings.isNullOrBlank(tableId.catalog())) {
+            quoted.append(InformixIdentifierQuoter.quoteIfNecessary(tableId.catalog())).append(':');
         }
 
-        String schemaName = tableId.schema();
-        if (!Strings.isNullOrBlank(schemaName)) {
-            builder.append(schemaName).append('.');
+        if (!Strings.isNullOrBlank(tableId.schema())) {
+            quoted.append(InformixIdentifierQuoter.quoteIfNecessary(tableId.schema())).append('.');
         }
 
-        return builder.append(tableId.table()).toString();
+        return quoted.append(InformixIdentifierQuoter.quoteIfNecessary(tableId.table())).toString();
     }
 
     @Override
     public String quotedColumnIdString(String columnName) {
-        // TODO: Unless DELIMIDENT is set, column names cannot be quoted
-        return columnName;
+        // Unless DELIMIDENT is set, column names cannot be quoted
+        return InformixIdentifierQuoter.quoteIfNecessary(columnName);
     }
 
     public DataSource datasource() {

--- a/src/main/java/io/debezium/connector/informix/InformixDatabaseSchema.java
+++ b/src/main/java/io/debezium/connector/informix/InformixDatabaseSchema.java
@@ -46,7 +46,7 @@ public class InformixDatabaseSchema extends HistorizedRelationalDatabaseSchema {
                         connectorConfig.getSourceInfoStructMaker().schema(),
                         connectorConfig.getFieldNamer(),
                         connectorConfig.multiPartitionMode()),
-                true,
+                false,
                 connectorConfig.getKeyMapper());
     }
 

--- a/src/main/java/io/debezium/connector/informix/InformixIdentifierQuoter.java
+++ b/src/main/java/io/debezium/connector/informix/InformixIdentifierQuoter.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.informix;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class InformixIdentifierQuoter {
+    private static final Pattern UNQUOTED = Pattern.compile("[\\p{Lower}\\p{Digit}_$]*");
+
+    public static String quoteIfNecessary(String identifier) {
+        Matcher matcher = UNQUOTED.matcher(identifier);
+
+        if (!matcher.matches() && !(identifier.startsWith("\"") && identifier.endsWith("\""))) {
+            return "\"%s\"".formatted(identifier);
+        }
+
+        return identifier;
+    }
+}

--- a/src/main/java/io/debezium/connector/informix/InformixStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/informix/InformixStreamingChangeEventSource.java
@@ -239,8 +239,8 @@ public class InformixStreamingChangeEventSource implements StreamingChangeEventS
                 .stopLoggingOnClose(connectorConfig.stopLoggingOnClose());
 
         schema.tableIds().forEach((TableId tid) -> {
-            String[] colNames = schema.tableFor(tid).retrieveColumnNames().toArray(String[]::new);
-            builder.watchTable(tid.identifier(), colNames);
+            String[] colNames = schema.tableFor(tid).retrieveColumnNames().stream().map(dataConnection::quotedColumnIdString).toArray(String[]::new);
+            builder.watchTable(dataConnection.quotedTableIdString(tid), colNames);
         });
 
         if (startLsn.isAvailable()) {

--- a/src/test/java/io/debezium/connector/informix/AbstractInformixDefaultValueIT.java
+++ b/src/test/java/io/debezium/connector/informix/AbstractInformixDefaultValueIT.java
@@ -87,11 +87,6 @@ public abstract class AbstractInformixDefaultValueIT extends AbstractAsyncEngine
     @Test
     @FixFor("DBZ-4990")
     public void shouldHandleNumericDefaultTypes() throws Exception {
-        // TODO: remove once https://github.com/Apicurio/apicurio-registry/issues/2990 is fixed
-        if (VerifyRecord.isApucurioAvailable()) {
-            skipAvroValidation();
-        }
-
         List<ColumnDefinition> columnDefinitions = List.of(
                 new ColumnDefinition("val_bigint", "BIGINT",
                         "1", "2",
@@ -120,10 +115,6 @@ public abstract class AbstractInformixDefaultValueIT extends AbstractAsyncEngine
     @Test
     @FixFor("DBZ-4990")
     public void shouldHandleFloatPointDefaultTypes() throws Exception {
-        // TODO: remove once https://github.com/Apicurio/apicurio-registry/issues/2980 is fixed
-        if (VerifyRecord.isApucurioAvailable()) {
-            skipAvroValidation();
-        }
 
         List<ColumnDefinition> columnDefinitions = Arrays.asList(
                 new ColumnDefinition("val_double", "DOUBLE PRECISION",

--- a/src/test/java/io/debezium/connector/informix/IncrementalSnapshotIT.java
+++ b/src/test/java/io/debezium/connector/informix/IncrementalSnapshotIT.java
@@ -183,7 +183,6 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Infor
     @Test
     @Ignore("Informix does not support DDL operations on tables defined for replication")
     @Override
-    public void snapshotPreceededBySchemaChange() throws Exception {
-        super.snapshotPreceededBySchemaChange();
+    public void snapshotPreceededBySchemaChange() {
     }
 }

--- a/src/test/java/io/debezium/connector/informix/InformixDelimitedIdentifiersIT.java
+++ b/src/test/java/io/debezium/connector/informix/InformixDelimitedIdentifiersIT.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.informix;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.connector.informix.InformixConnectorConfig.SnapshotMode;
+import io.debezium.connector.informix.util.TestHelper;
+import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
+
+public class InformixDelimitedIdentifiersIT extends AbstractAsyncEngineConnectorTest {
+
+    private static final String DELIMIDENT = "DELIMIDENT";
+
+    private InformixConnection connection;
+
+    @Before
+    public void before() throws SQLException {
+        connection = new InformixConnection(TestHelper.defaultJdbcConfig().with(DELIMIDENT, 1).build());
+        connection.execute(
+                "DROP TABLE IF EXISTS lower_case_table",
+                "DROP TABLE IF EXISTS \"UPPER_CASE_TABLE\"",
+                "DROP TABLE IF EXISTS \"mixed_CASE_table\"",
+                "DROP TABLE IF EXISTS \"TABLE\"",
+                "CREATE TABLE lower_case_table (text varchar(255))",
+                "CREATE TABLE \"UPPER_CASE_TABLE\" (\"TEXT\" varchar(255))",
+                "CREATE TABLE \"mixed_CASE_table\" (one varchar(255), \"TWO\" varchar(255), \"ThReE\" varchar(255))",
+                "CREATE TABLE \"TABLE\" (\"SELECT\" varchar(255))",
+                "INSERT INTO lower_case_table VALUES('text')",
+                "INSERT INTO \"UPPER_CASE_TABLE\" VALUES('TEXT')",
+                "INSERT INTO \"mixed_CASE_table\" VALUES('one', 'TWO', 'ThReE')",
+                "INSERT INTO \"TABLE\" VALUES('TEXT')");
+        initializeConnectorTestFramework();
+        Files.delete(TestHelper.SCHEMA_HISTORY_PATH);
+        Print.enable();
+    }
+
+    @After
+    public void after() throws SQLException {
+        /*
+         * Since all DDL operations are forbidden during Informix CDC,
+         * we have to ensure the connector is properly shut down before dropping tables.
+         */
+        stopConnector();
+        waitForConnectorShutdown(TestHelper.TEST_CONNECTOR, TestHelper.TEST_DATABASE);
+        assertConnectorNotRunning();
+        if (connection != null) {
+            connection.rollback()
+                    .execute(
+                            "DROP TABLE IF EXISTS lower_case_table",
+                            "DROP TABLE IF EXISTS \"UPPER_CASE_TABLE\"",
+                            "DROP TABLE IF EXISTS \"mixed_CASE_table\"",
+                            "DROP TABLE IF EXISTS \"TABLE\"")
+                    .close();
+        }
+    }
+
+    @Test
+    public void testDelimitedIdentifiers() throws Exception {
+
+        final Configuration config = TestHelper.defaultConfig()
+                .with(CommonConnectorConfig.DRIVER_CONFIG_PREFIX + DELIMIDENT, 1)
+                .with(InformixConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
+                .with(InformixConnectorConfig.TABLE_INCLUDE_LIST, "testdb.informix.lower_case_table," +
+                        "testdb.informix.UPPER_CASE_TABLE," +
+                        "testdb.informix.mixed_CASE_table," +
+                        "testdb.informix.TABLE")
+                .build();
+
+        start(InformixConnector.class, config);
+        assertConnectorIsRunning();
+
+        // Wait for snapshot completion
+        waitForSnapshotToBeCompleted(TestHelper.TEST_CONNECTOR, TestHelper.TEST_DATABASE);
+
+        SourceRecords sourceRecords = consumeRecordsByTopic(4);
+        List<SourceRecord> lowerCaseTable = sourceRecords.recordsForTopic("testdb.informix.lower_case_table");
+        List<SourceRecord> upperCaseTable = sourceRecords.recordsForTopic("testdb.informix.UPPER_CASE_TABLE");
+        List<SourceRecord> mixedCaseTable = sourceRecords.recordsForTopic("testdb.informix.mixed_CASE_table");
+        List<SourceRecord> table = sourceRecords.recordsForTopic("testdb.informix.TABLE");
+        assertThat(lowerCaseTable).hasSize(1);
+        assertThat(upperCaseTable).hasSize(1);
+        assertThat(mixedCaseTable).hasSize(1);
+        assertThat(table).hasSize(1);
+        assertNoRecordsToConsume();
+
+        // Wait for streaming to start
+        waitForStreamingRunning(TestHelper.TEST_CONNECTOR, TestHelper.TEST_DATABASE);
+
+        connection.execute(
+                "INSERT INTO lower_case_table VALUES('TEXT')",
+                "INSERT INTO \"UPPER_CASE_TABLE\" VALUES('text')",
+                "INSERT INTO \"mixed_CASE_table\" VALUES('ONE', 'two', 'tHrEe')",
+                "INSERT INTO \"TABLE\" VALUES('TEXT')");
+
+        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
+
+        sourceRecords = consumeRecordsByTopic(4);
+        lowerCaseTable = sourceRecords.recordsForTopic("testdb.informix.lower_case_table");
+        upperCaseTable = sourceRecords.recordsForTopic("testdb.informix.UPPER_CASE_TABLE");
+        mixedCaseTable = sourceRecords.recordsForTopic("testdb.informix.mixed_CASE_table");
+        table = sourceRecords.recordsForTopic("testdb.informix.TABLE");
+        assertThat(lowerCaseTable).hasSize(1);
+        assertThat(upperCaseTable).hasSize(1);
+        assertThat(mixedCaseTable).hasSize(1);
+        assertThat(table).hasSize(1);
+        assertNoRecordsToConsume();
+    }
+}

--- a/src/test/java/io/debezium/connector/informix/InformixValidateColumnOrderIT.java
+++ b/src/test/java/io/debezium/connector/informix/InformixValidateColumnOrderIT.java
@@ -93,9 +93,9 @@ public class InformixValidateColumnOrderIT extends AbstractAsyncEngineConnectorT
                 "age", "18",
                 "gender", "male",
                 "address", "ff:ff:ff:ff:ff:ff");
-        connection.execute(String.format("insert into %s(%s) values(\"%s\")", testTableName,
+        connection.execute(String.format("insert into %s(%s) values('%s')", testTableName,
                 Strings.join(", ", recordToBeInsert.keySet()),
-                Strings.join("\", \"", recordToBeInsert.values())));
+                Strings.join("', '", recordToBeInsert.values())));
 
         waitForAvailableRecords();
 
@@ -121,9 +121,9 @@ public class InformixValidateColumnOrderIT extends AbstractAsyncEngineConnectorT
                 "age", "18",
                 "gender", "male",
                 "address", "ff:ff:ff:ff:ff:ff");
-        connection.execute(String.format("insert into %s(%s) values(\"%s\")", testTableName,
+        connection.execute(String.format("insert into %s(%s) values('%s')", testTableName,
                 Strings.join(", ", recordToBeUpdate.keySet()),
-                Strings.join("\", \"", recordToBeUpdate.values())));
+                Strings.join("', '", recordToBeUpdate.values())));
 
         final Configuration config = TestHelper.defaultConfig()
                 .with(InformixConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
@@ -140,7 +140,7 @@ public class InformixValidateColumnOrderIT extends AbstractAsyncEngineConnectorT
         recordAfterUpdate.put("address", "00:00:00:00:00:00");
 
         // update
-        connection.execute(String.format("update %s set address = \"%s\" where id = \"%s\"", testTableName,
+        connection.execute(String.format("update %s set address = '%s' where id = '%s'", testTableName,
                 recordAfterUpdate.get("address"), recordToBeUpdate.get("id")));
 
         waitForAvailableRecords();
@@ -170,9 +170,9 @@ public class InformixValidateColumnOrderIT extends AbstractAsyncEngineConnectorT
                 "age", "18",
                 "gender", "male",
                 "address", "ff:ff:ff:ff:ff:ff");
-        connection.execute(String.format("insert into %s(%s) values(\"%s\")", testTableName,
+        connection.execute(String.format("insert into %s(%s) values('%s')", testTableName,
                 Strings.join(", ", recordToBeDelete.keySet()),
-                Strings.join("\", \"", recordToBeDelete.values())));
+                Strings.join("', '", recordToBeDelete.values())));
 
         final Configuration config = TestHelper.defaultConfig()
                 .with(InformixConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
@@ -185,7 +185,7 @@ public class InformixValidateColumnOrderIT extends AbstractAsyncEngineConnectorT
         waitForStreamingRunning(TestHelper.TEST_CONNECTOR, TestHelper.TEST_DATABASE);
         waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
 
-        connection.execute(String.format("delete from %s where id = \"%s\"", testTableName, recordToBeDelete.get("id")));
+        connection.execute(String.format("delete from %s where id = '%s'", testTableName, recordToBeDelete.get("id")));
 
         waitForAvailableRecords();
 

--- a/src/test/java/io/debezium/connector/informix/util/TestHelper.java
+++ b/src/test/java/io/debezium/connector/informix/util/TestHelper.java
@@ -55,24 +55,22 @@ public class TestHelper {
      */
     public static final String IS_CDC_ENABLED = "select name, is_logging, is_buff_log, is_ansi from sysmaster:sysdatabases where name='%s'";
 
-    public static JdbcConfiguration adminJdbcConfig() {
+    public static JdbcConfiguration.Builder adminJdbcConfig() {
         return JdbcConfiguration.copy(Configuration.fromSystemProperties(InformixConnectorConfig.DATABASE_CONFIG_PREFIX))
                 .withDefault(JdbcConfiguration.DATABASE, TEST_DATABASE)
                 .withDefault(JdbcConfiguration.HOSTNAME, "localhost")
                 .withDefault(JdbcConfiguration.PORT, 9088)
                 .withDefault(JdbcConfiguration.USER, "informix")
-                .withDefault(JdbcConfiguration.PASSWORD, "in4mix")
-                .build();
+                .withDefault(JdbcConfiguration.PASSWORD, "in4mix");
     }
 
-    public static JdbcConfiguration defaultJdbcConfig() {
+    public static JdbcConfiguration.Builder defaultJdbcConfig() {
         return JdbcConfiguration.copy(Configuration.fromSystemProperties(InformixConnectorConfig.DATABASE_CONFIG_PREFIX))
                 .withDefault(JdbcConfiguration.DATABASE, TEST_DATABASE)
                 .withDefault(JdbcConfiguration.HOSTNAME, "localhost")
                 .withDefault(JdbcConfiguration.PORT, 9088)
                 .withDefault(JdbcConfiguration.USER, "informix")
-                .withDefault(JdbcConfiguration.PASSWORD, "in4mix")
-                .build();
+                .withDefault(JdbcConfiguration.PASSWORD, "in4mix");
     }
 
     /**
@@ -81,7 +79,7 @@ public class TestHelper {
      */
     public static Configuration.Builder defaultConfig() {
 
-        return Configuration.copy(defaultJdbcConfig().map(key -> InformixConnectorConfig.DATABASE_CONFIG_PREFIX + key))
+        return Configuration.copy(defaultJdbcConfig().build().map(key -> InformixConnectorConfig.DATABASE_CONFIG_PREFIX + key))
                 .with(CommonConnectorConfig.TOPIC_PREFIX, TEST_DATABASE)
                 .with(RelationalDatabaseConnectorConfig.SNAPSHOT_LOCK_TIMEOUT_MS, TimeUnit.SECONDS.toMillis(30))
                 .with(InformixConnectorConfig.SCHEMA_HISTORY, FileSchemaHistory.class)
@@ -92,7 +90,7 @@ public class TestHelper {
     }
 
     public static InformixConnection adminConnection() {
-        return new InformixConnection(TestHelper.adminJdbcConfig());
+        return new InformixConnection(TestHelper.adminJdbcConfig().build());
     }
 
     public static void dropTable(InformixConnection connection, String table) throws SQLException {
@@ -106,7 +104,7 @@ public class TestHelper {
     }
 
     private static class LazyConnectionHolder {
-        static final InformixConnection INSTANCE = new InformixConnection(TestHelper.defaultJdbcConfig());
+        static final InformixConnection INSTANCE = new InformixConnection(TestHelper.defaultJdbcConfig().build());
     }
 
     public static InformixConnection testConnection() {


### PR DESCRIPTION
Upper and mixed case identifiers requires the database/sql interpreter to be configured with Delimited Identifiers and `[driver.]DELIMIDENT=1` to be set in the connector configuration.