### PR TITLE
[ci] Mark tests as flaky after DBZ-9460

### DIFF
--- a/src/test/java/io/debezium/connector/informix/IncrementalSnapshotIT.java
+++ b/src/test/java/io/debezium/connector/informix/IncrementalSnapshotIT.java
@@ -22,6 +22,7 @@ import io.debezium.connector.informix.InformixConnectorConfig.SnapshotMode;
 import io.debezium.connector.informix.util.TestHelper;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.junit.ConditionalFail;
+import io.debezium.junit.Flaky;
 import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotTest;
 
 public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<InformixConnector> {
@@ -173,5 +174,19 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Infor
     @Ignore("Informix does not support DDL operations on tables defined for replication")
     @Override
     public void snapshotPreceededBySchemaChange() {
+    }
+
+    @Test
+    @Flaky("DBZ-9460")
+    @Override
+    public void removeNotYetCapturedCollectionFromInProgressIncrementalSnapshot() throws Exception {
+        super.removeNotYetCapturedCollectionFromInProgressIncrementalSnapshot();
+    }
+
+    @Test
+    @Flaky("DBZ-9460")
+    @Override
+    public void removeStartedCapturedCollectionFromInProgressIncrementalSnapshot() throws Exception {
+        super.removeStartedCapturedCollectionFromInProgressIncrementalSnapshot();
     }
 }


### PR DESCRIPTION
Something seems to have been introduced in DBZ-9460 that only affects Informix 12 and under some conditions (tests pass locally)