### PR TITLE
DBZ-9512 Add strimzi-test-container dependency to make core repo pass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>strimzi-test-container</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Required by VerifyRecord -->
         <dependency>


### PR DESCRIPTION
This PR adds strimzi-test-container dependency to the `Informix` connector. That should solve the current problem in the Debezium core repository, which is:
```java
Error:  Errors: 
Error:    IncrementalSnapshotIT.initializationError » NoClassDefFound io/strimzi/test/container/StrimziKafkaCluster
[INFO]
```