### PR TITLE
debezium/dbz#1766 Replace unsupported types with placeholder values

### DIFF
--- a/src/main/java/io/debezium/connector/informix/InformixChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/informix/InformixChangeRecordEmitter.java
@@ -8,7 +8,6 @@ package io.debezium.connector.informix;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import com.informix.jdbc.IfxUDT;
 import com.informix.jdbc.types.ReadableType;
 import com.informix.jdbc.udt.BasicUdt;
 
@@ -33,7 +32,6 @@ public class InformixChangeRecordEmitter extends RelationalChangeRecordEmitter<I
     private final Operation operation;
     private final Map<String, ReadableType> before;
     private final Map<String, ReadableType> after;
-    private final IfxUDT placeholderValue;
 
     public InformixChangeRecordEmitter(InformixPartition partition, InformixOffsetContext offsetContext, Clock clock,
                                        InformixConnectorConfig connectorConfig, InformixDatabaseSchema schema, TableId tableId,
@@ -45,7 +43,6 @@ public class InformixChangeRecordEmitter extends RelationalChangeRecordEmitter<I
         this.operation = operation;
         this.before = before;
         this.after = after;
-        this.placeholderValue = new BasicUdt(connectorConfig.getUnavailableValuePlaceholder());
     }
 
     @Override
@@ -74,7 +71,7 @@ public class InformixChangeRecordEmitter extends RelationalChangeRecordEmitter<I
         // based on the schema columns, create the values on the same position as the columns
         return data == null ? new Object[table.columns().size()]
                 : table.retrieveColumnNames().stream()
-                        .map(key -> data.getOrDefault(key, placeholderValue))
+                        .map(colName -> data.getOrDefault(colName, new BasicUdt()))
                         .map(type -> propagate(type::toObject)).toArray();
     }
 

--- a/src/main/java/io/debezium/connector/informix/InformixConnection.java
+++ b/src/main/java/io/debezium/connector/informix/InformixConnection.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 
 import com.informix.jdbc.IfxDriver;
 import com.informix.jdbcx.IfxDataSource;
+import com.informix.lang.IfxTypes;
 
 import io.debezium.DebeziumException;
 import io.debezium.config.CommonConnectorConfig;
@@ -133,16 +134,13 @@ public class InformixConnection extends JdbcConnection {
     }
 
     @Override
+    protected int resolveNativeType(String typeName) {
+        return IfxTypes.FromIfxNameToIfxType(typeName);
+    }
+
+    @Override
     public String buildSelectPrimaryKeyBoundaries(TableId tableId, long size, String projection, String orderBy) {
-        return new StringBuilder("SELECT ")
-                .append("SKIP ").append(size)
-                .append(" FIRST 1 ")
-                .append(projection)
-                .append(" FROM ")
-                .append(quotedTableIdString(tableId))
-                .append(" ORDER BY ")
-                .append(orderBy)
-                .toString();
+        return "SELECT SKIP %d FIRST 1 %s FROM %s ORDER BY %s".formatted(size, projection, quotedTableIdString(tableId), orderBy);
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/informix/InformixStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/informix/InformixStreamingChangeEventSource.java
@@ -9,13 +9,20 @@ import static java.lang.Thread.currentThread;
 
 import java.sql.SQLException;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.informix.jdbc.IfxUDT;
 import com.informix.jdbc.stream.api.StreamOperationRecord;
 import com.informix.jdbc.stream.api.StreamRecord;
 import com.informix.jdbc.stream.cdc.records.CDCBeginTransactionRecord;
@@ -24,11 +31,13 @@ import com.informix.jdbc.stream.cdc.records.CDCMetaDataRecord;
 import com.informix.jdbc.stream.cdc.records.CDCTruncateRecord;
 import com.informix.jdbc.stream.impl.StreamException;
 import com.informix.jdbc.types.ReadableType;
+import com.informix.lang.IfxTypes;
 
 import io.debezium.data.Envelope.Operation;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
+import io.debezium.relational.Column;
 import io.debezium.relational.TableId;
 import io.debezium.schema.SchemaChangeEvent;
 import io.debezium.util.Clock;
@@ -47,6 +56,8 @@ public class InformixStreamingChangeEventSource implements StreamingChangeEventS
     private final ErrorHandler errorHandler;
     private final Clock clock;
     private final InformixDatabaseSchema schema;
+    private final byte[] unavailableValuePlaceholder;
+    private final Multimap<TableId, Column> reselectColumns = ArrayListMultimap.create();
     private InformixOffsetContext effectiveOffsetContext;
 
     public InformixStreamingChangeEventSource(InformixConnectorConfig connectorConfig,
@@ -60,6 +71,7 @@ public class InformixStreamingChangeEventSource implements StreamingChangeEventS
         this.errorHandler = errorHandler;
         this.clock = clock;
         this.schema = schema;
+        this.unavailableValuePlaceholder = connectorConfig.getUnavailableValuePlaceholder();
     }
 
     @Override
@@ -225,11 +237,24 @@ public class InformixStreamingChangeEventSource implements StreamingChangeEventS
                 .returnEmptyTransactions(connectorConfig.returnEmptytransactions())
                 .context(context);
 
+        reselectColumns.clear();
+
         schema.tableIds().forEach((TableId tid) -> {
-            String[] colNames = schema.tableFor(tid).retrieveColumnNames().stream()
-                    .filter(colName -> schema.getColumnFilter().matches(tid.catalog(), tid.schema(), tid.table(), colName))
-                    .map(dataConnection::quoteIdentifier).toArray(String[]::new);
-            builder.watchTable(dataConnection.quotedTableIdString(tid), colNames);
+            Map<Boolean, List<Column>> columns = schema.tableFor(tid).columns().stream()
+                    .filter(column -> schema.getColumnFilter().matches(tid.catalog(), tid.schema(), tid.table(), column.name()))
+                    // Filter unsupported columns for reselection...
+                    .collect(Collectors.partitioningBy(
+                            column -> column.nativeType() == IfxTypes.IFX_TYPE_BYTE ||
+                                    column.nativeType() == IfxTypes.IFX_TYPE_TEXT ||
+                                    column.nativeType() == IfxTypes.IFX_TYPE_UDTVAR ||
+                                    column.nativeType() == IfxTypes.IFX_TYPE_UDTFIXED ||
+                                    column.nativeType() == IfxTypes.IFX_TYPE_UNKNOWN ||
+                                    IfxTypes.isComplexType(column.nativeType())));
+            reselectColumns.putAll(tid, columns.get(true));
+            builder.watchTable(dataConnection.quotedTableIdString(tid),
+                    columns.get(false).stream()
+                            .map(Column::name).map(dataConnection::quoteIdentifier)
+                            .toArray(String[]::new));
         });
 
         if (startLsn.isAvailable()) {
@@ -441,7 +466,75 @@ public class InformixStreamingChangeEventSource implements StreamingChangeEventS
             throws InterruptedException {
         offsetContext.event(tableId, clock.currentTime());
 
+        // add unavailable value placeholders for unsupported columns
+        if (reselectColumns.containsKey(tableId)) {
+            for (Column column : reselectColumns.get(tableId)) {
+                if (before != null) {
+                    before.put(column.name(), new UnavailableValuePlaceholderType(unavailableValuePlaceholder, column.jdbcType(), column.nativeType()));
+                }
+                if (after != null) {
+                    after.put(column.name(), new UnavailableValuePlaceholderType(unavailableValuePlaceholder, column.jdbcType(), column.nativeType()));
+                }
+            }
+        }
+
         dispatcher.dispatchDataChangeEvent(partition, tableId,
                 new InformixChangeRecordEmitter(partition, offsetContext, clock, connectorConfig, schema, tableId, operation, before, after));
+    }
+
+    static class UnavailableValuePlaceholderType extends IfxUDT {
+
+        protected final byte[] bytes;
+        protected final List<Byte> list;
+
+        UnavailableValuePlaceholderType(byte[] unavailableValuePlaceholder, int jdbcType, int ifxType) {
+            this.bytes = unavailableValuePlaceholder;
+            this.list = new ArrayList<>(bytes.length);
+            for (byte b : bytes) {
+                list.add(b);
+            }
+            this.jdbcType = jdbcType;
+            this.ifxType = ifxType;
+            this.isNull = bytes == null;
+        }
+
+        @Override
+        public byte[] toBytes() {
+            return bytes;
+        }
+
+        @Override
+        public String toString() {
+            return new String(bytes);
+        }
+
+        public Collection<?> toCollection() {
+            return Collections.unmodifiableCollection(list);
+        }
+
+        @Override
+        public Object toObject() {
+            switch (ifxType) {
+                case IfxTypes.IFX_TYPE_BYTE,
+                        IfxTypes.IFX_TYPE_UDTVAR,
+                        IfxTypes.IFX_TYPE_UDTFIXED,
+                        IfxTypes.IFX_TYPE_UNKNOWN -> {
+                    return toBytes();
+                }
+                case IfxTypes.IFX_TYPE_TEXT -> {
+                    return toString();
+                }
+                case IfxTypes.IFX_TYPE_SET,
+                        IfxTypes.IFX_TYPE_MULTISET,
+                        IfxTypes.IFX_TYPE_LIST,
+                        IfxTypes.IFX_TYPE_ROW,
+                        IfxTypes.IFX_TYPE_COLLECTION -> {
+                    return toCollection();
+                }
+                default -> {
+                    return null;
+                }
+            }
+        }
     }
 }

--- a/src/test/java/io/debezium/connector/informix/InformixConnectorIT.java
+++ b/src/test/java/io/debezium/connector/informix/InformixConnectorIT.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -80,7 +81,7 @@ public class InformixConnectorIT extends AbstractAsyncEngineConnectorTest {
                 "CREATE TABLE masked_hashed_column_table (id int not null, name varchar(255), name2 varchar(255), name3 varchar(20), primary key (id))",
                 "CREATE TABLE truncated_column_table (id int not null, name varchar(20), primary key (id))",
                 "CREATE TABLE truncate_table (id int not null, name varchar(20), primary key (id))",
-                "CREATE TABLE dt_table (id int not null, c1 int, c2 int, c3a numeric(5,2), c3b varchar(128), f1 float(14), f2 decimal(8,4), primary key(id))",
+                "CREATE TABLE dt_table (id int not null, c1 int, c2 int, c3a numeric(5,2), c3b varchar(128), f1 float(14), f2 decimal(8,4), t1 text, b1 byte, primary key(id))",
                 "CREATE TABLE always_snapshot (id int not null, data varchar(50) not null, primary key(id))",
                 "CREATE TABLE test_heartbeat_table (text varchar(255))",
                 "INSERT INTO tablea VALUES(1, 'a')");
@@ -667,16 +668,18 @@ public class InformixConnectorIT extends AbstractAsyncEngineConnectorTest {
                 .with(InformixConnectorConfig.SNAPSHOT_MODE, snapshotMode)
                 .with(InformixConnectorConfig.STORE_ONLY_CAPTURED_TABLES_DDL, true)
                 .with(InformixConnectorConfig.TABLE_INCLUDE_LIST, "testdb.informix.dt_table")
-                .with(InformixConnectorConfig.COLUMN_INCLUDE_LIST, "informix.dt_table.id,informix.dt_table.c1,informix.dt_table.c3a,informix.dt_table.f1")
+                .with(InformixConnectorConfig.COLUMN_INCLUDE_LIST,
+                        "informix.dt_table.id,informix.dt_table.c1,informix.dt_table.c3a,,informix.dt_table.f1,informix.dt_table.t1")
                 .build();
 
-        final int expectedRecords;
+        int expectedRecords = 1;
         if (snapshotMode == SnapshotMode.INITIAL) {
             expectedRecords = 2;
-            connection.execute("INSERT INTO dt_table (id,c1,c2,c3a,c3b,f1,f2) values (0,123,456,789.01,'test',1.228,2.3456)");
-        }
-        else {
-            expectedRecords = 1;
+            connection.prepareUpdate("INSERT INTO dt_table (id,c1,c2,c3a,c3b,f1,f2,t1,b1) values (0,123,456,789.01,'test',1.228,2.3456,?,?)",
+                    ps -> {
+                        ps.setString(1, "text");
+                        ps.setBytes(2, "bytes".getBytes());
+                    }).commit();
         }
 
         start(InformixConnector.class, config);
@@ -689,7 +692,11 @@ public class InformixConnectorIT extends AbstractAsyncEngineConnectorTest {
         waitForStreamingRunning(TestHelper.TEST_CONNECTOR, TestHelper.TEST_DATABASE);
         waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
 
-        connection.execute("INSERT INTO dt_table (id,c1,c2,c3a,c3b,f1,f2) values (1,123,456,789.01,'test',1.228,2.3456)");
+        connection.prepareUpdate("INSERT INTO dt_table (id,c1,c2,c3a,c3b,f1,f2,t1,b1) values (1,123,456,789.01,'test',1.228,2.3456,?,?)",
+                ps -> {
+                    ps.setString(1, "text");
+                    ps.setBytes(2, "bytes".getBytes());
+                }).commit();
 
         waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
 
@@ -702,18 +709,21 @@ public class InformixConnectorIT extends AbstractAsyncEngineConnectorTest {
                 .field("c1", Schema.OPTIONAL_INT32_SCHEMA)
                 .field("c3a", SpecialValueDecimal.builder(DecimalMode.PRECISE, 5, 2).optional().build())
                 .field("f1", Schema.OPTIONAL_FLOAT64_SCHEMA)
+                .field("t1", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
         Struct aStruct = new Struct(aSchema)
+                .put("id", 0)
                 .put("c1", 123)
                 .put("c3a", BigDecimal.valueOf(789.01))
-                .put("f1", 1.228);
+                .put("f1", 1.228)
+                .put("t1", "text");
+        int r = 0;
         if (snapshotMode == SnapshotMode.INITIAL) {
-            SourceRecordAssert.assertThat(table.get(0)).valueAfterFieldIsEqualTo(aStruct.put("id", 0));
-            SourceRecordAssert.assertThat(table.get(1)).valueAfterFieldIsEqualTo(aStruct.put("id", 1));
+            SourceRecordAssert.assertThat(table.get(r++)).valueAfterFieldIsEqualTo(aStruct);
         }
-        else {
-            SourceRecordAssert.assertThat(table.get(0)).valueAfterFieldIsEqualTo(aStruct.put("id", 1));
-        }
+        aStruct.put("id", 1)
+                .put("t1", "__debezium_unavailable_value");
+        SourceRecordAssert.assertThat(table.get(r)).valueAfterFieldIsEqualTo(aStruct);
 
         assertNoRecordsToConsume();
     }
@@ -735,16 +745,17 @@ public class InformixConnectorIT extends AbstractAsyncEngineConnectorTest {
                 .with(InformixConnectorConfig.SNAPSHOT_MODE, snapshotMode)
                 .with(InformixConnectorConfig.STORE_ONLY_CAPTURED_TABLES_DDL, true)
                 .with(InformixConnectorConfig.TABLE_EXCLUDE_LIST, "testdb.informix.tablea")
-                .with(InformixConnectorConfig.COLUMN_EXCLUDE_LIST, "informix.dt_table.c1,informix.dt_table.c3a,informix.dt_table.f1")
+                .with(InformixConnectorConfig.COLUMN_EXCLUDE_LIST, "informix.dt_table.c1,informix.dt_table.c3a,informix.dt_table.f1,informix.dt_table.t1")
                 .build();
 
-        final int expectedRecords;
+        int expectedRecords = 1;
         if (snapshotMode == SnapshotMode.INITIAL) {
             expectedRecords = 2;
-            connection.execute("INSERT INTO dt_table (id,c1,c2,c3a,c3b,f1,f2) values (0,123,456,789.01,'test',1.228,2.3456)");
-        }
-        else {
-            expectedRecords = 1;
+            connection.prepareUpdate("INSERT INTO dt_table (id,c1,c2,c3a,c3b,f1,f2,t1,b1) values (0,123,456,789.01,'test',1.228,2.3456,?,?)",
+                    ps -> {
+                        ps.setString(1, "text");
+                        ps.setBytes(2, "bytes".getBytes());
+                    }).commit();
         }
 
         start(InformixConnector.class, config);
@@ -757,7 +768,11 @@ public class InformixConnectorIT extends AbstractAsyncEngineConnectorTest {
         waitForStreamingRunning(TestHelper.TEST_CONNECTOR, TestHelper.TEST_DATABASE);
         waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
 
-        connection.execute("INSERT INTO dt_table (id,c1,c2,c3a,c3b,f1,f2) values (1,123,456,789.01,'test',1.228,2.3456)");
+        connection.prepareUpdate("INSERT INTO dt_table (id,c1,c2,c3a,c3b,f1,f2,t1,b1) values (1,123,456,789.01,'test',1.228,2.3456,?,?)",
+                ps -> {
+                    ps.setString(1, "text");
+                    ps.setBytes(2, "bytes".getBytes());
+                }).commit();
 
         waitForAvailableRecords(waitTimeForRecords() * 5L, TimeUnit.SECONDS);
 
@@ -770,18 +785,21 @@ public class InformixConnectorIT extends AbstractAsyncEngineConnectorTest {
                 .field("c2", Schema.OPTIONAL_INT32_SCHEMA)
                 .field("c3b", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("f2", SpecialValueDecimal.builder(DecimalMode.PRECISE, 8, 4).optional().build())
+                .field("b1", Schema.OPTIONAL_BYTES_SCHEMA)
                 .build();
         Struct aStruct = new Struct(aSchema)
+                .put("id", 0)
                 .put("c2", 456)
                 .put("c3b", "test")
-                .put("f2", BigDecimal.valueOf(2.3456));
+                .put("f2", BigDecimal.valueOf(2.3456))
+                .put("b1", ByteBuffer.wrap("bytes".getBytes()));
+        int r = 0;
         if (snapshotMode == SnapshotMode.INITIAL) {
-            SourceRecordAssert.assertThat(table.get(0)).valueAfterFieldIsEqualTo(aStruct.put("id", 0));
-            SourceRecordAssert.assertThat(table.get(1)).valueAfterFieldIsEqualTo(aStruct.put("id", 1));
+            SourceRecordAssert.assertThat(table.get(r++)).valueAfterFieldIsEqualTo(aStruct);
         }
-        else {
-            SourceRecordAssert.assertThat(table.get(0)).valueAfterFieldIsEqualTo(aStruct.put("id", 1));
-        }
+        aStruct.put("id", 1)
+                .put("b1", ByteBuffer.wrap("__debezium_unavailable_value".getBytes()));
+        SourceRecordAssert.assertThat(table.get(r)).valueAfterFieldIsEqualTo(aStruct);
 
         assertNoRecordsToConsume();
     }

--- a/src/test/java/io/debezium/connector/informix/InformixReselectColumnsProcessorIT.java
+++ b/src/test/java/io/debezium/connector/informix/InformixReselectColumnsProcessorIT.java
@@ -5,12 +5,27 @@
  */
 package io.debezium.connector.informix;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.util.List;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.informix.util.TestHelper;
+import io.debezium.data.Envelope;
+import io.debezium.data.VerifyRecord;
+import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.processors.AbstractReselectProcessorTest;
 import io.debezium.processors.reselect.ReselectColumnsPostProcessor;
 import io.debezium.util.Testing;
@@ -25,7 +40,6 @@ public class InformixReselectColumnsProcessorIT extends AbstractReselectProcesso
     @BeforeEach
     public void beforeEach() throws Exception {
         connection = TestHelper.testConnection();
-        connection.setAutoCommit(false);
 
         initializeConnectorTestFramework();
         Testing.Files.delete(TestHelper.SCHEMA_HISTORY_PATH);
@@ -39,11 +53,6 @@ public class InformixReselectColumnsProcessorIT extends AbstractReselectProcesso
         assertConnectorNotRunning();
 
         super.afterEach();
-        if (connection != null) {
-            connection.rollback()
-                    .execute("DROP TABLE dbz4321")
-                    .close();
-        }
     }
 
     @Override
@@ -70,7 +79,7 @@ public class InformixReselectColumnsProcessorIT extends AbstractReselectProcesso
 
     @Override
     protected String tableName() {
-        return "informix.dbz4321";
+        return "dbz4321";
     }
 
     @Override
@@ -80,12 +89,15 @@ public class InformixReselectColumnsProcessorIT extends AbstractReselectProcesso
 
     @Override
     protected void createTable() throws Exception {
-        connection.execute("DROP TABLE IF EXISTS DBZ4321");
-        connection.execute("CREATE TABLE DBZ4321 (id int not null, data varchar(50), data2 int, primary key(id))");
+        connection.execute("CREATE TABLE dbz4321 (id int not null, data varchar(50), data2 int, primary key(id));");
     }
 
     @Override
     protected void dropTable() throws Exception {
+        connection.execute(
+                "DROP TABLE IF EXISTS dbz4321",
+                "DROP TABLE IF EXISTS dbz4321_byte",
+                "DROP TABLE IF EXISTS dbz4321_text");
     }
 
     @Override
@@ -104,13 +116,108 @@ public class InformixReselectColumnsProcessorIT extends AbstractReselectProcesso
         waitForStreamingRunning(TestHelper.TEST_CONNECTOR, TestHelper.TEST_DATABASE);
     }
 
+    @Override
     protected SourceRecords consumeRecordsByTopicReselectWhenNullStreaming() throws InterruptedException {
         waitForAvailableRecords();
         return super.consumeRecordsByTopicReselectWhenNullStreaming();
     }
 
+    @Override
     protected SourceRecords consumeRecordsByTopicReselectWhenNotNullStreaming() throws InterruptedException {
         waitForAvailableRecords();
         return super.consumeRecordsByTopicReselectWhenNotNullStreaming();
+    }
+
+    @Test
+    @FixFor("dbz#1766")
+    public void testColumnReselectedWhenTextValueIsUnavailable() throws Exception {
+        connection.execute("CREATE TABLE dbz4321_text (id int primary key, data text, data2 int);");
+
+        final LogInterceptor reselectLogInterceptor = getReselectLogInterceptor();
+
+        Configuration config = getConfigurationBuilder()
+                .with(InformixConnectorConfig.TABLE_INCLUDE_LIST, "testdb.informix.dbz4321_text")
+                .build();
+
+        start(getConnectorClass(), config);
+        assertConnectorIsRunning();
+
+        waitForStreamingStarted();
+
+        final String text = RandomStringUtils.randomAlphabetic(10000);
+        final Clob clob = connection.connection().createClob();
+        clob.setString(1, text);
+
+        connection.prepareUpdate("INSERT INTO dbz4321_text (id, data, data2) values (1, ?, 1);",
+                ps -> ps.setClob(1, clob)).commit();
+        connection.execute("UPDATE dbz4321_text SET data2 = 2 where id = 1;");
+
+        final SourceRecords sourceRecords = consumeRecordsByTopic(2);
+        final List<SourceRecord> tableRecords = sourceRecords.recordsForTopic("testdb.informix.dbz4321_text");
+
+        // Check insert
+        SourceRecord record = tableRecords.get(0);
+        Struct after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+        VerifyRecord.isValidInsert(record, "id", 1);
+        assertThat(after.get("id")).isEqualTo(1);
+        assertThat(after.get("data")).isEqualTo(text);
+        assertThat(after.get("data2")).isEqualTo(1);
+
+        // Check update
+        record = tableRecords.get(1);
+        after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+        VerifyRecord.isValidUpdate(record, "id", 1);
+        assertThat(after.get("id")).isEqualTo(1);
+        assertThat(after.get("data")).isEqualTo(text);
+        assertThat(after.get("data2")).isEqualTo(2);
+
+        assertColumnReselectedForUnavailableValue(reselectLogInterceptor, "testdb.informix.dbz4321_text", "data");
+    }
+
+    @Test
+    @FixFor("dbz#1766")
+    public void testColumnReselectedWhenByteValueIsUnavailable() throws Exception {
+        connection.execute("CREATE TABLE dbz4321_byte (id int primary key, data byte, data2 int);");
+
+        final LogInterceptor reselectLogInterceptor = getReselectLogInterceptor();
+
+        Configuration config = getConfigurationBuilder()
+                .with(InformixConnectorConfig.TABLE_INCLUDE_LIST, "testdb.informix.dbz4321_byte")
+                .build();
+
+        start(getConnectorClass(), config);
+        assertConnectorIsRunning();
+
+        waitForStreamingStarted();
+
+        final String text = RandomStringUtils.randomAlphabetic(10000);
+        final Blob blob = connection.connection().createBlob();
+        blob.setBytes(0, text.getBytes());
+        ByteBuffer wrapped = ByteBuffer.wrap(text.getBytes());
+
+        connection.prepareUpdate("INSERT INTO dbz4321_byte (id, data, data2) values (1, ?, 1);",
+                ps -> ps.setBlob(1, blob)).commit();
+        connection.execute("UPDATE dbz4321_byte SET data2 = 2 where id = 1;");
+
+        final SourceRecords sourceRecords = consumeRecordsByTopic(2);
+        final List<SourceRecord> tableRecords = sourceRecords.recordsForTopic("testdb.informix.dbz4321_byte");
+
+        // Check insert
+        SourceRecord record = tableRecords.get(0);
+        Struct after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+        VerifyRecord.isValidInsert(record, "id", 1);
+        assertThat(after.get("id")).isEqualTo(1);
+        assertThat(after.get("data")).isEqualTo(wrapped);
+        assertThat(after.get("data2")).isEqualTo(1);
+
+        // Check update
+        record = tableRecords.get(1);
+        after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+        VerifyRecord.isValidUpdate(record, "id", 1);
+        assertThat(after.get("id")).isEqualTo(1);
+        assertThat(after.get("data")).isEqualTo(wrapped);
+        assertThat(after.get("data2")).isEqualTo(2);
+
+        assertColumnReselectedForUnavailableValue(reselectLogInterceptor, "testdb.informix.dbz4321_byte", "data");
     }
 }


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/1766

Automatically remove columns of unsupported types (BYTE, TEXT) from watched tables and replace with unavailable.value.placeholder (similar to toasted values in Postgres)

