### PR TITLE
debezium/dbz#1622 moving Informix JDBC driver dependency to Debezium Parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,6 @@
         <dependency>
             <groupId>com.ibm.informix</groupId>
             <artifactId>jdbc</artifactId>
-            <version>15.0.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Moving Informix JDBC v15 driver dependency to Debezium Parent, where it belongs

See debezium/debezium#7300