### PR TITLE
debezium/dbz#1803 Quick fix for Ifx JDBC Driver v15.0.1.1 (backport to 3.5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,6 @@
         <dependency>
             <groupId>com.ibm.informix</groupId>
             <artifactId>jdbc</artifactId>
-            <version>15.0.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/debezium/connector/informix/InformixCdcTransactionEngine.java
+++ b/src/main/java/io/debezium/connector/informix/InformixCdcTransactionEngine.java
@@ -138,6 +138,11 @@ public class InformixCdcTransactionEngine implements TransactionEngine {
     }
 
     @Override
+    public List<StreamRecord> getRecords() throws SQLException, StreamException {
+        return engine.getRecords();
+    }
+
+    @Override
     public InformixStreamTransactionRecord getTransaction() throws SQLException, StreamException {
         StreamRecord streamRecord;
         while ((streamRecord = getRecord()) != null && !(streamRecord instanceof InformixStreamTransactionRecord)) {
@@ -227,6 +232,15 @@ public class InformixCdcTransactionEngine implements TransactionEngine {
 
         public int getBufferSize() {
             return builder.getBufferSize();
+        }
+
+        public Builder maxRecords(int maxRecords) {
+            builder.maxRecords(maxRecords);
+            return this;
+        }
+
+        public int getMaxRecords() {
+            return builder.getMaxRecords();
         }
 
         public Builder sequenceId(long position) {

--- a/src/main/java/io/debezium/connector/informix/InformixConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/informix/InformixConnectorConfig.java
@@ -41,6 +41,8 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
 
     protected static final int DEFAULT_CDC_BUFFERSIZE = 0x10000;
 
+    protected static final int DEFAULT_CDC_MAX_RECORDS = 1;
+
     protected static final int DEFAULT_CDC_TIMEOUT = 5;
 
     protected static final boolean DEFAULT_CDC_STOP_ON_CLOSE = true;
@@ -382,6 +384,15 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
             .withValidation(Field::isBoolean)
             .withDefault(DEFAULT_RETURN_EMPTY_TRANSACTIONS);
 
+    public static final Field CDC_MAX_RECORDS = Field.create("cdc.max.records")
+            .withDisplayName("CDC Engine Max Records")
+            .withType(ConfigDef.Type.INT)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 4))
+            .withWidth(Width.MEDIUM).withImportance(Importance.MEDIUM)
+            .withDescription("The maximum number of CDC records to return per read function call.")
+            .withValidation(Field::isNonNegativeInteger)
+            .withDefault(DEFAULT_CDC_MAX_RECORDS);
+
     public static final Field SOURCE_INFO_STRUCT_MAKER = CommonConnectorConfig.SOURCE_INFO_STRUCT_MAKER
             .withDefault(InformixSourceInfoStructMaker.class.getName());
 
@@ -409,6 +420,7 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
                     FIELD_NAME_ADJUSTMENT_MODE,
                     INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
                     CDC_BUFFERSIZE,
+                    CDC_MAX_RECORDS,
                     CDC_TIMEOUT,
                     CDC_STOP_ON_CLOSE,
                     RETURN_EMPTY_TRANSACTIONS)
@@ -430,6 +442,7 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
     private final SnapshotIsolationMode snapshotIsolationMode;
     private final JdbcConfiguration cdcJdbcConfig;
     private final int cdcBuffersize;
+    private final int cdcMaxRecords;
     private final int cdcTimeout;
     private final boolean stopLoggingOnClose;
     private final boolean returnEmptytransactions;
@@ -452,6 +465,7 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
         this.snapshotLockingMode = SnapshotLockingMode.parse(config.getString(SNAPSHOT_LOCKING_MODE), SNAPSHOT_LOCKING_MODE.defaultValueAsString());
         this.cdcJdbcConfig = JdbcConfiguration.adapt(getJdbcConfig().edit().with(JdbcConfiguration.DATABASE, CDC_DATABASE).build());
         this.cdcBuffersize = config.getInteger(CDC_BUFFERSIZE);
+        this.cdcMaxRecords = config.getInteger(CDC_MAX_RECORDS);
         this.cdcTimeout = config.getInteger(CDC_TIMEOUT);
         this.stopLoggingOnClose = config.getBoolean(CDC_STOP_ON_CLOSE);
         this.returnEmptytransactions = config.getBoolean(RETURN_EMPTY_TRANSACTIONS);
@@ -480,6 +494,10 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
 
     public int getCdcBuffersize() {
         return cdcBuffersize;
+    }
+
+    public int getCdcMaxRecords() {
+        return cdcMaxRecords;
     }
 
     public int getCdcTimeout() {

--- a/src/main/java/io/debezium/connector/informix/InformixStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/informix/InformixStreamingChangeEventSource.java
@@ -220,6 +220,7 @@ public class InformixStreamingChangeEventSource implements StreamingChangeEventS
         InformixCdcTransactionEngine.Builder builder = InformixCdcTransactionEngine
                 .builder(dataConnection.datasource())
                 .buffer(connectorConfig.getCdcBuffersize())
+                .maxRecords(connectorConfig.getCdcMaxRecords())
                 .timeout(connectorConfig.getCdcTimeout())
                 .stopLoggingOnClose(connectorConfig.stopLoggingOnClose())
                 .returnEmptyTransactions(connectorConfig.returnEmptytransactions())


### PR DESCRIPTION
Backport to 3.5 of quick fix for Ifx JDBC Driver v15.0.1.1, setting MaxRecords=1 as default. 

Depends on debezium/debezium#7352