### PR TITLE
debezium/dbz#453 Derive field group order implicitly from ConfigDefinition ordering

### DIFF
--- a/src/main/java/io/debezium/connector/informix/InformixConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/informix/InformixConnectorConfig.java
@@ -297,7 +297,7 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
 
     public static final Field SNAPSHOT_MODE = Field.create("snapshot.mode")
             .withDisplayName("Snapshot mode")
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 0))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT))
             .withEnum(SnapshotMode.class, SnapshotMode.INITIAL)
             .withWidth(Width.SHORT)
             .withImportance(Importance.MEDIUM)
@@ -316,7 +316,7 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
     public static final Field SNAPSHOT_ISOLATION_MODE = Field.create("snapshot.isolation.mode")
             .withDisplayName("Snapshot isolation mode")
             .withEnum(SnapshotIsolationMode.class, SnapshotIsolationMode.REPEATABLE_READ)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 1))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT))
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
             .withDescription("Controls which transaction isolation level is used and how long the connector locks the monitored tables. "
@@ -334,7 +334,7 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
             .withEnum(SnapshotLockingMode.class, SnapshotLockingMode.EXCLUSIVE)
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 4))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT))
             .withDescription(
                     "Controls how the connector holds locks on tables while performing the schema snapshot when `snapshot.isolation.mode` is `REPEATABLE_READ` or `EXCLUSIVE`. The 'exclusive' "
                             + "which means the connector will hold a table lock for exclusive table access for just the initial portion of the snapshot "
@@ -346,7 +346,7 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
     public static final Field CDC_BUFFERSIZE = Field.create("cdc.buffersize")
             .withDisplayName("CDC Engine buffer size")
             .withType(ConfigDef.Type.INT)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 0))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(Width.MEDIUM).withImportance(Importance.MEDIUM)
             .withDescription("Size of the read buffer for receiving events from the server, in bytes.")
             .withValidation(Field::isNonNegativeInteger)
@@ -355,7 +355,7 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
     public static final Field CDC_TIMEOUT = Field.create("cdc.timeout")
             .withDisplayName("CDC Engine timeout")
             .withType(ConfigDef.Type.INT)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 1))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.MEDIUM)
             .withDescription("Specifies a timeout to interrupt blocking to wait on an event, in seconds. "
@@ -367,7 +367,7 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
     public static final Field CDC_STOP_ON_CLOSE = Field.create("cdc.stop.logging.on.close")
             .withDisplayName("CDC Stop Logging on Close")
             .withType(ConfigDef.Type.BOOLEAN)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 2))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(Width.SHORT)
             .withImportance(Importance.MEDIUM)
             .withDescription("Whether Informix should stop Full Row Logging of watched tables when streaming is closed.")
@@ -377,7 +377,7 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
     public static final Field RETURN_EMPTY_TRANSACTIONS = Field.create("cdc.return.empty.transactions")
             .withDisplayName("CDC Return Empty Transactions")
             .withType(ConfigDef.Type.BOOLEAN)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 3))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(Width.SHORT)
             .withImportance(Importance.MEDIUM)
             .withDescription("Whether Informix should return and emit transaction records for empty transactions.")
@@ -387,7 +387,7 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
     public static final Field CDC_MAX_RECORDS = Field.create("cdc.max.records")
             .withDisplayName("CDC Engine Max Records")
             .withType(ConfigDef.Type.INT)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 4))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
             .withWidth(Width.MEDIUM).withImportance(Importance.MEDIUM)
             .withDescription("The maximum number of CDC records to return per read function call.")
             .withValidation(Field::isNonNegativeInteger)
@@ -397,34 +397,15 @@ public class InformixConnectorConfig extends HistorizedRelationalDatabaseConnect
             .withDefault(InformixSourceInfoStructMaker.class.getName());
 
     public static final Field FIELD_NAME_ADJUSTMENT_MODE = CommonConnectorConfig.FIELD_NAME_ADJUSTMENT_MODE
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 8));
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR));
 
     private static final ConfigDefinition CONFIG_DEFINITION = HistorizedRelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
             .name("Informix")
-            .type(
-                    HOSTNAME,
-                    PORT,
-                    USER,
-                    PASSWORD,
-                    DATABASE_NAME,
-                    QUERY_TIMEOUT_MS)
-            .connector(
-                    SNAPSHOT_MODE,
-                    SNAPSHOT_ISOLATION_MODE,
-                    SNAPSHOT_QUERY_MODE,
-                    SNAPSHOT_QUERY_MODE_CUSTOM_NAME,
-                    SNAPSHOT_LOCKING_MODE,
-                    SNAPSHOT_LOCKING_MODE_CUSTOM_NAME,
-                    BINARY_HANDLING_MODE,
-                    SCHEMA_NAME_ADJUSTMENT_MODE,
-                    FIELD_NAME_ADJUSTMENT_MODE,
-                    INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
-                    CDC_BUFFERSIZE,
-                    CDC_MAX_RECORDS,
-                    CDC_TIMEOUT,
-                    CDC_STOP_ON_CLOSE,
-                    RETURN_EMPTY_TRANSACTIONS)
-            .events(SOURCE_INFO_STRUCT_MAKER)
+            .group(Field.Group.CONNECTION, HOSTNAME, PORT, USER, PASSWORD, DATABASE_NAME, QUERY_TIMEOUT_MS)
+            .group(Field.Group.CONNECTOR_SNAPSHOT, SNAPSHOT_MODE, SNAPSHOT_ISOLATION_MODE, SNAPSHOT_QUERY_MODE, SNAPSHOT_QUERY_MODE_CUSTOM_NAME,
+                    SNAPSHOT_LOCKING_MODE, SNAPSHOT_LOCKING_MODE_CUSTOM_NAME, INCREMENTAL_SNAPSHOT_CHUNK_SIZE)
+            .group(Field.Group.CONNECTOR, BINARY_HANDLING_MODE, SCHEMA_NAME_ADJUSTMENT_MODE, FIELD_NAME_ADJUSTMENT_MODE, SOURCE_INFO_STRUCT_MAKER)
+            .group(Field.Group.CONNECTOR_ADVANCED, CDC_BUFFERSIZE, CDC_MAX_RECORDS, CDC_TIMEOUT, CDC_STOP_ON_CLOSE, RETURN_EMPTY_TRANSACTIONS)
             .excluding(INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES)
             .create();
 


### PR DESCRIPTION
This PR applies the changes from debezium/debezium#7286 to the Informix connector.

## Changes
- Removed explicit position numbers from all `createGroupEntry(Field.Group.XXX, N)` calls, replacing them with `createGroupEntry(Field.Group.XXX)`
- Replaced the old `.type()/.connector()/.events()` API with the new `.group()` API in `InformixConnectorConfig`

## Details
Following the pattern established in debezium/debezium#7286, this change removes manual position numbers from field group entries and derives group order implicitly from the order fields appear in the ConfigDefinition. This eliminates the need to maintain explicit position numbers and reduces the risk of ordering conflicts.

Fixes dbz#453