### PR TITLE
debezium/dbz#870 Assert schema history default as a String value

### DIFF
--- a/src/test/java/io/debezium/connector/informix/InformixConnectorTest.java
+++ b/src/test/java/io/debezium/connector/informix/InformixConnectorTest.java
@@ -26,7 +26,7 @@ public class InformixConnectorTest {
             assertThat(key.documentation).isEqualTo(expected.description());
             assertThat(key.type).isEqualTo(expected.type());
             if (expected.equals(InformixConnectorConfig.SCHEMA_HISTORY)) {
-                assertThat(((Class<?>) key.defaultValue).getName()).isEqualTo(expected.defaultValue());
+                assertThat(key.defaultValue).isEqualTo(expected.defaultValue());
             }
             assertThat(key.dependents).isEqualTo(expected.dependents());
             assertThat(key.width).isNotNull();


### PR DESCRIPTION
Fixes debezium/dbz#870

## Description

Companion to debezium/debezium#7659, which declares the shared `schema.history.internal` field as `Type.STRING` instead of `Type.CLASS` so the default schema history class is no longer eagerly loaded when the configuration definition is built (it now lives in an optional module that may be absent, e.g. the embedded engine).

`InformixConnectorTest.assertConfigDefIsValid` special-cases `InformixConnectorConfig.SCHEMA_HISTORY` and casts `key.defaultValue` to `Class`. With the field declared as `STRING` the default value is now a `String`, so that cast throws `ClassCastException` and `shouldReturnConfigurationDefinition` fails.

This compares the default value directly instead, mirroring the Oracle and SQL Server connector tests updated in #7659. The assertion stays live — it still verifies the advertised default equals `SCHEMA_HISTORY.defaultValue()`, and would fail clearly if the field ever reverted to a `Class` default.

The Cross Maven CI builds core from the matching `dbz-870-schema-history-classtype` branch (this PR pairs with debezium/debezium#7659), so it exercises the `STRING` field.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
